### PR TITLE
TF Update (1.6.x) compatability

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -76,7 +76,7 @@ module "s3_access_log_bucket" {
 
 data "aws_iam_policy_document" "default" {
   count       = module.this.enabled ? 1 : 0
-  source_json = var.policy == "" ? null : var.policy
+  source_policy_documents = [var.policy == "" ? null : var.policy]
 
   statement {
     sid = "AWSCloudTrailAclCheck"

--- a/main.tf
+++ b/main.tf
@@ -76,7 +76,7 @@ module "s3_access_log_bucket" {
 
 data "aws_iam_policy_document" "default" {
   count       = module.this.enabled ? 1 : 0
-  source_policy_documents = [var.policy == "" ? null : var.policy]
+  source_policy_documents = [var.policy]
 
   statement {
     sid = "AWSCloudTrailAclCheck"

--- a/main.tf
+++ b/main.tf
@@ -44,7 +44,7 @@ module "s3_bucket" {
 
 module "s3_access_log_bucket" {
   source  = "cloudposse/s3-log-storage/aws"
-  version = "0.26.0"
+  version = "1.0.0"
   enabled = module.this.enabled && var.create_access_log_bucket
 
   acl                                    = var.acl


### PR DESCRIPTION
We are making a jump (terraform version) from 1.0.9 to 1.6.5
- `s3_access_log_bucket` module is not compatible (0.26.0)
- `s3_access_log_bucket` module version (1.0.0) is finally compatible. 
- `source_json` is not present any more , We are using `source_policy_documents`  from now. 
